### PR TITLE
Update c_sharp_differences.rst with C# string and Godot String UTF encoding

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -381,6 +381,8 @@ Use ``System.String`` (``string``). Most of Godot's String methods have an
 equivalent in ``System.String`` or are provided by the ``StringExtensions``
 class as extension methods.
 
+Note that C# strings uses UTF-16 encoding, while Godot Strings uses UTF-32 encoding.
+
 Example:
 
 .. code-block:: csharp


### PR DESCRIPTION
Clarified that C# System.String uses UTF-16 encoding while Godot String uses UTF-32.